### PR TITLE
Fix the next page link

### DIFF
--- a/payment-gateways/index.md
+++ b/payment-gateways/index.md
@@ -2,7 +2,7 @@
 chapter = true
 icon = "<i class='fa fa-money fa-fw'></i>"
 title = "Payment Gateways"
-next = "/gateway-modules/getting-started"
+next = "/payment-gateways/getting-started"
 weight = 0
 
 +++


### PR DESCRIPTION
The next page link was pointing to `gateway-modules/getting-started` where it should be pointing`payment-gateways/getting-started`.