### PR TITLE
Typo in Update Invoice link

### DIFF
--- a/api/api-index.md
+++ b/api/api-index.md
@@ -38,7 +38,7 @@ weight = 100
 <li> <a href="/api-reference/getquotes/">GetQuotes</a>
 <li> <a href="/api-reference/gettransactions/">GetTransactions</a>
 <li> <a href="/api-reference/sendquote/">SendQuote</a>
-<li> <a href="/api-reference/updateinvoice/">CreateInvoice</a>
+<li> <a href="/api-reference/updateinvoice/">UpdateInvoice</a>
 <li> <a href="/api-reference/updatequote/">UpdateQuote</a>
 <li> <a href="/api-reference/updatetransaction/">UpdateTransaction</a>
 </ul>


### PR DESCRIPTION
Update Invoice link had the Text `CreateInvoice` updated to `UpdateInvoice`