### PR TITLE
Update client-area-interface.md to resolve typo in code example

### DIFF
--- a/hooks-reference/client-area-interface.md
+++ b/hooks-reference/client-area-interface.md
@@ -160,7 +160,7 @@ A key/value pair array of additional template variables to define.
 ```
 <?php
 
-add_hook('AdminAreaPage', 1, function($vars) {
+add_hook('ClientAreaPageLogin', 1, function($vars) {
     $extraVariables = [
         'newVariable1' => 'thisValue',
         'newVariable2' => 'thatValue',


### PR DESCRIPTION
typo in the ClientAreaPageLogin code snippet for the actual hook name