### PR TITLE
updated Hook Index to reference AdminLogin

### DIFF
--- a/hooks-reference/admin-area.md
+++ b/hooks-reference/admin-area.md
@@ -374,6 +374,29 @@ add_hook('AdminHomepage', 1, function($vars) {
 });
 ```
 
+## AdminLogin
+
+Executes on Admin log in
+
+#### Parameters
+
+| Variable | Type | Notes |
+| -------- | ---- | ----- |
+| adminid | int |  |
+
+#### Response
+
+No Response supported
+
+#### Example code
+
+```
+<?php
+add_hook('AdminLogin', 1, function($vars) {
+    // Perform hook code here...
+});
+```
+
 ## AdminLogout
 
 Executes on Admin log out
@@ -515,4 +538,3 @@ add_hook('PreAdminServiceEdit', 1, function($vars) {
     // Perform hook code here...
 });
 ```
-

--- a/hooks/hook-index.md
+++ b/hooks/hook-index.md
@@ -275,6 +275,7 @@ weight = 100
 <li> <a href="/hooks-reference/admin-area/#adminclientservicestabfields">AdminClientServicesTabFields</a>
 <li> <a href="/hooks-reference/admin-area/#adminclientservicestabfieldssave">AdminClientServicesTabFieldsSave</a>
 <li> <a href="/hooks-reference/admin-area/#adminhomepage">AdminHomepage</a>
+<li> <a href="/hooks-reference/admin-area/#adminlogin">AdminLogin</a>
 <li> <a href="/hooks-reference/admin-area/#adminlogout">AdminLogout</a>
 <li> <a href="/hooks-reference/admin-area/#adminproductconfigfields">AdminProductConfigFields</a>
 <li> <a href="/hooks-reference/admin-area/#adminproductconfigfieldssave">AdminProductConfigFieldsSave</a>


### PR DESCRIPTION
Updating Hooks developer docs for missing AdminLogin hook point which previously referenced here: http://docs.whmcs.com/Hooks:AdminLogin