### PR TITLE
add provisioning module Meta Data Parameters to dev docs

### DIFF
--- a/provisioning-modules/meta-data-params.md
+++ b/provisioning-modules/meta-data-params.md
@@ -1,0 +1,24 @@
++++
+next = ""
+prev = "/provisioning-modules/module-logging"
+title = "Meta Data Parameters"
+toc = true
+weight = 120
+
++++
+
+[Provisioning Modules][provisioning-modules] support a number of meta data configuration parameters.
+
+They include:
+
+| Name | Type | Supported As Of | Default | Value | Description |
+| --- | --- | --- | --- | --- | --- | --- |
+| `DisplayName` | Text | 6.0 | NA | | | *An alternate display name that will be used instead of the filename if defined* |
+| `APIVersion` | Text | 5.2 | 1.1 | | *Defines API Version the module uses. Use `1.1` unless you have a need specific to use `1.0`* |
+| `RequiresServer` | Boolean | 6.0 | | true/false | *Defines whether the module requires servers to function. A lot of modules these days don't require servers be configured so setting this to false prevents users creating servers assigned to it.* |
+| `DefaultNonSSLPort` | Integer | 6.0 | NA | | *If specified, will display by default when configuring a server with the module when `Use SSL` is disabled and will allow a user to override it should they wish.  Use this if your API can operate on varying port numbers.* |
+| `DefaultSSLPort` | Integer | 6.0 | NA | | *If specified, will display by default when configuring a server with the module when `Use SSL` is disabled and will allow a user to override it should they wish.  Use this if your API can operate on varying port numbers.* |
+| `ServiceSingleSignOnLabel` | Text | 6.0 | NA | | *For use with Single Sign-On, define here what you want to show as the text label for the Single Sign-On option for an instance of a service under a client.* |
+| `AdminSingleSignOnLable` | Text | 6.0 | NA | | *For use with Single Sign-On, define here what you want to show as the text label for the Single Sign-On option for a server assigned to the module within the admin area.* |
+
+[provisioning-modules]: /provisioning-modules "Provisioning Modules"

--- a/provisioning-modules/module-logging.md
+++ b/provisioning-modules/module-logging.md
@@ -1,5 +1,5 @@
 +++
-next = ""
+next = "/provisioning-modules/meta-data-params"
 prev = "/provisioning-modules/admin-dashboard-widgets"
 title = "Module Logging"
 toc = true


### PR DESCRIPTION
DOCS-6558

Created the Provisioning Module Meta Data Parameters page for inclusion into our docs.  Showing how to properly format the config_array meta data tags when building out your custom module to work with WHMCS.