### PR TITLE
Added md5 hashing for password in example

### DIFF
--- a/api-reference/gettickets.md
+++ b/api-reference/gettickets.md
@@ -41,7 +41,7 @@ curl_setopt($ch, CURLOPT_POSTFIELDS,
         array(
             'action' => 'GetTickets',
             'username' => 'ADMIN_USERNAME',
-            'password' => 'ADMIN_PASSWORD',
+            'password' => md5('ADMIN_PASSWORD'),
             'responsetype' => 'json',
         )
     )


### PR DESCRIPTION
Password must be converted to hash with md5 before sending. It is missing in the example. Wrapped password with md5().