### PR TITLE
Update getannouncements.md

### DIFF
--- a/api-reference/getannouncements.md
+++ b/api-reference/getannouncements.md
@@ -35,7 +35,7 @@ curl_setopt($ch, CURLOPT_POSTFIELDS,
         array(
             'action' => 'GetAnnouncements',
             'username' => 'ADMIN_USERNAME',
-            'password' => 'ADMIN_PASSWORD',
+            'password' => hash('md5', 'ADMIN_PASSWORD'),
             'responsetype' => 'json',
         )
     )


### PR DESCRIPTION
All examples in the documentation fail to make clear that the admin password needs to be hashed using md5. The examples make it seem that you are sending it as clear text.