### PR TITLE
Fix broken link when clicking on next and previous link

### DIFF
--- a/payment-gateways/meta-data-params.md
+++ b/payment-gateways/meta-data-params.md
@@ -1,6 +1,6 @@
 +++
-prev = "/provisioning-modules/getting-started"
-next = "/provisioning-modules/configuration"
+prev = "/payment-gateways/getting-started/"
+next = "/payment-gateways/configuration/"
 title = "Meta Data Parameters"
 toc = true
 weight = 15


### PR DESCRIPTION
When you click on next and previous link from this page, you get a 404 error.

https://developers.whmcs.com/payment-gateways/meta-data-params/