### PR TITLE
serversecure does not return true / false

### DIFF
--- a/provisioning-modules/module-parameters.md
+++ b/provisioning-modules/module-parameters.md
@@ -32,7 +32,7 @@ The parameters also contains the settings from the product itself.
 | serverusername | The Username of the selected server. |
 | serverpassword | The Password of the selected server. |
 | serveraccesshash | The Access Hash of the selected server. |
-| serversecure | true/false - Is an SSL connection enabled in the Server Configuration. |
+| serversecure | on or empty - Is an SSL connection enabled in the Server Configuration. |
 | serverport | The server port if module supports override with custom port |
 
 ## Config Options <a id="config-options"></a>


### PR DESCRIPTION
In my test (WHMCS v7.6.0) the serversecure array key returns "on" if the checkbox at the server configuration has been setted or is empty, if it is disabled.

Maybe on a previous WHMCS version it was true / false, but it seems it got changed.