### PR TITLE
Update getting-started.md

### DIFF
--- a/notification-providers/getting-started.md
+++ b/notification-providers/getting-started.md
@@ -7,12 +7,6 @@ weight = 10
 
 +++
 
-## Sample Module
-
-We make available a sample notification module on Github. We recommend using this as a starting point for a custom module.
-
-> https://github.com/WHMCS/sample-notification-module
-
 ## Choosing a Name
 
 Notification Modules are stored in the `/modules/notifications/` directory.


### PR DESCRIPTION
Sample module GitHub link is returning 404. There is no sample module folder in WHMCS repo.