### PR TITLE
Clarified how we handle when server modules gets a new hooks.php file added

### DIFF
--- a/hooks/module-hooks.md
+++ b/hooks/module-hooks.md
@@ -13,8 +13,8 @@ Module hooks follow all the same principles as regular hooks.
 
 To provide hooks as part of a module, create a file named `hooks.php` in the root of your module directory.
 
-This hooks file will be detected and loaded by WHMCS on every page load.
+This hooks file will be loaded by WHMCS on every page load.
 
 {{% notice note %}}
-Hook files are only detected at the time a module is activated and configured. If you add your hook file after the module has already been activated, you may need to deactivate and reactivate your module in order for WHMCS to recognise it.
+Hook files are only detected at the time a module is activated and configured. If you add your hook file after the module has already been activated, you may need to deactivate and reactivate your module in order for WHMCS to recognise it. For server modules, this can be accomplished by accessing the Module Settings tab of an applicable product under (**Setup** > **Products/Services** > **Products/Services**) and clicking `Save Changes`.
 {{% /notice %}}

--- a/hooks/module-hooks.md
+++ b/hooks/module-hooks.md
@@ -16,5 +16,5 @@ To provide hooks as part of a module, create a file named `hooks.php` in the roo
 This hooks file will be loaded by WHMCS on every page load.
 
 {{% notice note %}}
-Hook files are only detected at the time a module is activated and configured. If you add your hook file after the module has already been activated, you may need to deactivate and reactivate your module in order for WHMCS to recognise it. For server modules, this can be accomplished by accessing the Module Settings tab of an applicable product under (**Setup** > **Products/Services** > **Products/Services**) and clicking `Save Changes`.
+Hook files are only detected at the time a module is activated and configured. If you add your hook file after the module has already been activated, you may need to deactivate and reactivate your module in order for WHMCS to recognise it. For server modules, this can be accomplished by accessing the Module Settings tab of an applicable product under **Setup** > **Products/Services** > **Products/Services** and clicking **Save Changes**.
 {{% /notice %}}


### PR DESCRIPTION
Added a note that it is necessary to edit an associated product to get WHMCS to recognize when a hooks.php file is added to an existing server module and removed a portion that says new hooks.php files will be detected automatically (they won't for server modules or any other type)