### PR TITLE
Wrong function name: IrtpTransferLockExpiryDate

### DIFF
--- a/domain-registrars/transfer-policy-management.md
+++ b/domain-registrars/transfer-policy-management.md
@@ -23,7 +23,7 @@ A description of the methods used in WHOIS Contact Verification messaging are pr
 | setIsIrtpEnabled | Boolean | Must be set to true to enable Transfer Policy functionality. |
 | setIrtpOptOutStatus | Boolean | True or false depending on the current opt-out status for the Inter Registry Transfer Policy (optional) |
 | setIrtpTransferLock | Boolean | True or false depending on the current IRTP Transfer Lock status for the given domain (optional) |
-| IrtpTransferLockExpiryDate | Date | The expiry date of the transfer lock (optional) |
+| setIrtpTransferLockExpiryDate | Date | The expiry date of the transfer lock (optional) |
 | setDomainContactChangePending | Boolean | True if a WHOIS Contact Verification process is in progress |
 | setPendingSuspension | Boolean | True if failure to complete the current WHOIS Contact Verification process will result in domain suspension (typically for new registrations) |
 | setDomainContactChangeExpiryDate | Date | The date by which the current WHOIS Contact Verification process must be completed by |
@@ -42,7 +42,7 @@ function modulename_GetDomainInformation(array $params) {
         ->setIsIrtpEnabled(true)
         ->setIrtpOptOutStatus(false)
         ->setIrtpTransferLock(true)
-        ->IrtpTransferLockExpiryDate(Carbon::createFromFormat('Y-m-d', '2019-06-15'))
+        ->setIrtpTransferLockExpiryDate(Carbon::createFromFormat('Y-m-d', '2019-06-15'))
         ->setDomainContactChangePending(true)
         ->setPendingSuspension(true)
         ->setDomainContactChangeExpiryDate(Carbon::createFromFormat('Y-m-d', '2018-08-20'))


### PR DESCRIPTION
Function is described as `IrtpTransferLockExpiryDate` when it should be `setIrtpTransferLockExpiryDate`