### PR TITLE
setIdProtectionStatus() does not do anything

### DIFF
--- a/domain-registrars/domain-information.md
+++ b/domain-registrars/domain-information.md
@@ -40,7 +40,6 @@ function modulename_GetDomainInformation($params) {
         ->setTransferLockExpiryDate(null)
         ->setExpiryDate(Carbon::createFromFormat('Y-m-d', $response['expirydate'])) // $response['expirydate'] = YYYY-MM-DD
         ->setRestorable(false)
-        ->setIdProtectionStatus($response['addons']['hasidprotect'])
         ->getDnsManagementStatus($response['addons']['hasdnsmanagement'])
         ->setEmailForwardingStatus($response['addons']['hasemailforwarding'])
         ->setIsIrtpEnabled(in_array($response['tld'], ['.com']))


### PR DESCRIPTION
setIdProtectionStatus(true) or setIdProtectionStatus(false) does not change either the display of the domain data in the Admin Area or Client Area. It also does not save the value to the database after it returns the Domain object to WHMCS. Therefore what's the point in having it here?

If it is to remain, then it should be accompanied with notes indicating that it doesn't do anything and that if you want to actually save the live ID Protection status from the registrar, you need to *also* do something like this:
```
  $affected = Capsule::table('tbldomains')
            ->where('id', $params['domainid'])
            ->update([ 'idprotection' => $response['addons']['idprotect'] ]);
```