### PR TITLE
Add $params to the loader function for clarity

### DIFF
--- a/provisioning-modules/loader-functions.md
+++ b/provisioning-modules/loader-functions.md
@@ -49,7 +49,7 @@ WHMCS will recognize an Exception and display the error message returned in that
  * Loader function that will populate the field in ConfigOptions
  * @return array The list of package names
  */
-function provisioningmodule_LoaderFunction() {
+function provisioningmodule_LoaderFunction($params) {
     // Make a call to the remote API endpoint
     $ch = curl_init('https://www.example.com/api/function');
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);


### PR DESCRIPTION
When calling the remote server to get package information you need access to the $params to use the remote  and not having it in the documentation was confusing. Thankfully a coworker pointed me in the right direction. 

I needed access to these ones specifically.

$params['serverhostname']
$params['serverport']
$params['serverusername']
$params['serverpassword']


