### PR TITLE
Fix type for cvv on CapturePayment

### DIFF
--- a/api-reference/capturepayment.md
+++ b/api-reference/capturepayment.md
@@ -11,7 +11,7 @@ Attempt to capture a payment on an unpaid CC Invoice
 | --------- | ---- | ----------- | -------- |
 | action | string | "CapturePayment" | Required |
 | invoiceid | int | The ID of the pending order | Required |
-| cvv |  | string The CVV Number for the card being attempted | Optional |
+| cvv | string | The CVV Number for the card being attempted | Optional |
 
 ### Response Parameters
 


### PR DESCRIPTION
String got tossed into the description, moved it back over