### PR TITLE
Add link reference for Interacting with the Database

### DIFF
--- a/provisioning-modules/service-properties.md
+++ b/provisioning-modules/service-properties.md
@@ -71,3 +71,5 @@ When using Service Properties against a service (for example, a directly-created
 * Last Update
 
 Using these field names with an addon will create a custom field.
+
+[db-interaction]: https://developers.whmcs.com/advanced/db-interaction/ "Interacting with the Database"


### PR DESCRIPTION
A link reference was forgotten causing the "Interacting with the Database" to display erroneously.

This change adds a reference to transform this into a link on next build