### PR TITLE
fix: userId is now clientId

### DIFF
--- a/advanced/logging.md
+++ b/advanced/logging.md
@@ -19,7 +19,7 @@ This function is available to all hooks, modules and template files throughout t
  * Log activity.
  *
  * @param string $message The message to log
- * @param int $userId An optional user id to which the log entry relates
+ * @param int $clientId An optional client id to which the log entry relates
  */
 logActivity('Message goes here', 0);
 ```


### PR DESCRIPTION
Hello. I believe it is now the case since v8 that the ID passed to logActivity should now be clientId and not userId?