### PR TITLE
removed extra column in table applycredit.md

### DIFF
--- a/api-reference/applycredit.md
+++ b/api-reference/applycredit.md
@@ -11,7 +11,7 @@ Applies the Client's Credit to an invoice
 | --------- | ---- | ----------- | -------- |
 | action | string | "ApplyCredit" | Required |
 | invoiceid | int | The ID of the invoice to apply credit | Required |
-| amount | float|string | The amount of credit to apply to the invoice. | Optional |
+| amount | float| The amount of credit to apply to the invoice. | Optional |
 | noemail | bool | Set to true to stop the invoice payment email being sent if the invoice becomes paid | Optional |
 
 ### Response Parameters


### PR DESCRIPTION
In the documentation there is an extra field stating that there are two types for this field "amount" since it's in markdown format we can't use the "|" symbol. If both types are accepted, you should use "or" instead of the pipe.